### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/lib/heca-lib/src/convert/year/backend.rs
+++ b/lib/heca-lib/src/convert/year/backend.rs
@@ -144,27 +144,27 @@ mod tests {
     #[test]
     fn years_correct_sum() {
         assert_eq!(
-            YEAR_SCHED[0].into_iter().map(|x| (*x) as u64).sum::<u64>(),
+            YEAR_SCHED[0].iter().map(|x| (*x) as u64).sum::<u64>(),
             353
         );
         assert_eq!(
-            YEAR_SCHED[1].into_iter().map(|x| (*x) as u64).sum::<u64>(),
+            YEAR_SCHED[1].iter().map(|x| (*x) as u64).sum::<u64>(),
             354
         );
         assert_eq!(
-            YEAR_SCHED[2].into_iter().map(|x| (*x) as u64).sum::<u64>(),
+            YEAR_SCHED[2].iter().map(|x| (*x) as u64).sum::<u64>(),
             355
         );
         assert_eq!(
-            YEAR_SCHED[3].into_iter().map(|x| (*x) as u64).sum::<u64>(),
+            YEAR_SCHED[3].iter().map(|x| (*x) as u64).sum::<u64>(),
             383
         );
         assert_eq!(
-            YEAR_SCHED[4].into_iter().map(|x| (*x) as u64).sum::<u64>(),
+            YEAR_SCHED[4].iter().map(|x| (*x) as u64).sum::<u64>(),
             384
         );
         assert_eq!(
-            YEAR_SCHED[5].into_iter().map(|x| (*x) as u64).sum::<u64>(),
+            YEAR_SCHED[5].iter().map(|x| (*x) as u64).sum::<u64>(),
             385
         );
     }

--- a/lib/heca-lib/src/holidays/mod.rs
+++ b/lib/heca-lib/src/holidays/mod.rs
@@ -842,7 +842,7 @@ mod test {
     #[test]
     fn check_shekalim_on_shabbos_mevorchim_or_rosh_chodesh() {
         use chrono::Duration;
-        for loc in [Location::Chul, Location::Israel].into_iter() {
+        for loc in [Location::Chul, Location::Israel].iter() {
             for i in 5764..9999 {
                 let y = HebrewYear::new(i).unwrap();
                 let date = if let Ok(date) =
@@ -867,7 +867,7 @@ mod test {
     #[test]
     fn check_hachodesh_on_shabbos_mevorchim_or_rosh_chodesh() {
         use chrono::Duration;
-        for loc in [Location::Chul, Location::Israel].into_iter() {
+        for loc in [Location::Chul, Location::Israel].iter() {
             for i in 5764..9999 {
                 let date = HebrewDate::from_ymd(i, HebrewMonth::Nissan, NonZeroI8::new(1).unwrap())
                     .unwrap()
@@ -887,7 +887,7 @@ mod test {
     #[test]
     fn check_zachor_on_shabbos_before_purim() {
         use chrono::Duration;
-        for loc in [Location::Chul, Location::Israel].into_iter() {
+        for loc in [Location::Chul, Location::Israel].iter() {
             for i in 5764..9999 {
                 let date = if let Ok(date) =
                     HebrewDate::from_ymd(i, HebrewMonth::Adar, NonZeroI8::new(14).unwrap())


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.
